### PR TITLE
fix client constructor

### DIFF
--- a/defectdojo_api_generated/client.py
+++ b/defectdojo_api_generated/client.py
@@ -49,7 +49,6 @@ class DefectDojo:
         else:
             self.config = config
 
-        # TODO: just python-requests as generator library...
         if self.config.proxy is None:
             scheme, host, *_ = urlparse(base_url)
             if not proxy_bypass(host):

--- a/defectdojo_api_generated/client.py
+++ b/defectdojo_api_generated/client.py
@@ -1,7 +1,7 @@
 # custom-templates/my_client.mustache
 """DefectDojo Client"""
 
-from typing import Optional
+from typing import Optional, Tuple, overload
 from urllib.parse import urlparse
 from urllib.request import getproxies, proxy_bypass
 
@@ -21,12 +21,29 @@ class DefectDojo:
     :param config: Configuration object to use. If provided, all other parameters are ignored.
     """
 
+    @overload
     def __init__(
         self,
         *,
         base_url: Optional[str] = None,
         token: Optional[str] = None,
-        auth: Optional[tuple[str]] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        verify_ssl: bool = True,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        config: Configuration,
+    ): ...
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        auth: Optional[Tuple[str, str]] = None,
         verify_ssl: bool = True,
         config: Optional[Configuration] = None,
     ):

--- a/defectdojo_api_generated/client.py
+++ b/defectdojo_api_generated/client.py
@@ -1,6 +1,7 @@
 # custom-templates/my_client.mustache
 """DefectDojo Client"""
 
+from typing import Optional
 from urllib.parse import urlparse
 from urllib.request import getproxies, proxy_bypass
 
@@ -11,23 +12,33 @@ from defectdojo_api_generated.configuration import Configuration
 class DefectDojo:
     """API client for DefectDojo.
 
-    :param base_url: base URL of the DefectDojo instance.
+    :param base_url: Base URL of the DefectDojo instance.
     :param token: API token to use with DefectDojo.
         Use this OR auth, not both.
-    :param auth: tuple with username and password for basic authentication with DefectDojo.
+    :param auth: Tuple with username and password for basic authentication with DefectDojo.
         Use this OR token, not both.
+    :param verify_ssl: Set this to false to skip verifying SSL server certificate.
     :param config: Configuration object to use. If provided, all other parameters are ignored.
     """
 
-    def __init__(self, base_url: str, token: str = None, auth: tuple[str] = None, config: Configuration = None):
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        auth: Optional[tuple[str]] = None,
+        verify_ssl: bool = True,
+        config: Optional[Configuration] = None,
+    ):
         if token is not None and auth is not None:
             raise ValueError('Provide `token` OR `auth`, not both.')
         if auth is not None and (not isinstance(auth, tuple) or len(auth) != 2):
             raise ValueError('`auth` needs to be a tuple with 2 elements, username and password')
 
         if config is None:
-            # drop last / (if any) as it is already added as part of endpoints
-            kwargs = {'host': base_url.rstrip('/')}
+            kwargs = {'verify_ssl': verify_ssl}
+            if base_url is not None:
+                kwargs['host'] = base_url
 
             if token is not None:
                 kwargs.update({'api_key': {'tokenAuth': token}, 'api_key_prefix': {'tokenAuth': 'Token'}})

--- a/defectdojo_api_generated/client.py
+++ b/defectdojo_api_generated/client.py
@@ -36,7 +36,7 @@ class DefectDojo:
             raise ValueError('`auth` needs to be a tuple with 2 elements, username and password')
 
         if config is None:
-            kwargs = {'verify_ssl': verify_ssl}
+            kwargs = {}
             if base_url is not None:
                 kwargs['host'] = base_url
 
@@ -46,11 +46,12 @@ class DefectDojo:
                 kwargs.update({'username': auth[0], 'password': auth[1]})
 
             self.config = Configuration(**kwargs)
+            self.config.verify_ssl = verify_ssl
         else:
             self.config = config
 
-        if self.config.proxy is None:
-            scheme, host, *_ = urlparse(base_url)
+        if self.config.proxy is None and self.config.host:
+            scheme, host, *_ = urlparse(self.config.host)
             if not proxy_bypass(host):
                 self.config.proxy = getproxies().get(scheme)
 

--- a/example.py
+++ b/example.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 
-from defectdojo_api_generated import DefectDojo
+from defectdojo_api_generated import DefectDojo, Configuration
 
 if __name__ == '__main__':
     # password publicly available in https://github.com/DefectDojo/django-DefectDojo/?tab=readme-ov-file#demo
-    dojo = DefectDojo('https://demo.defectdojo.org', auth=('admin', '1Defectdojo@demo#appsec'))
-    r = dojo.findings_api.findings_list()
-    print(f'{r.count} findings, example:\n')
-    print(r.results[0])
+    dojo = DefectDojo(base_url='https://demo.defectdojo.org/', auth=('admin', '1Defectdojo@demo#appsec'))
+    r = dojo.findings_api.findings_list(limit=1)
+    print(f'{r.count} findings, example:')
+    print(f'- [{r.results[0].severity}] {r.results[0].title} - {r.results[0].description}')
+
+    dojo = DefectDojo(config=Configuration(host='https://demo.defectdojo.org', username='admin', password='1Defectdojo@demo#appsec'))
+    r = dojo.system_settings_api.system_settings_list(limit=1)
+    print(f'{r.count} settings')
+    print(f'- {r.results[0]}')

--- a/example.py
+++ b/example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from defectdojo_api_generated import DefectDojo, Configuration
+from defectdojo_api_generated import Configuration, DefectDojo
 
 if __name__ == '__main__':
     # password publicly available in https://github.com/DefectDojo/django-DefectDojo/?tab=readme-ov-file#demo
@@ -9,7 +9,9 @@ if __name__ == '__main__':
     print(f'{r.count} findings, example:')
     print(f'- [{r.results[0].severity}] {r.results[0].title} - {r.results[0].description}')
 
-    dojo = DefectDojo(config=Configuration(host='https://demo.defectdojo.org', username='admin', password='1Defectdojo@demo#appsec'))
+    dojo = DefectDojo(
+        config=Configuration(host='https://demo.defectdojo.org', username='admin', password='1Defectdojo@demo#appsec')
+    )
     r = dojo.system_settings_api.system_settings_list(limit=1)
     print(f'{r.count} settings')
     print(f'- {r.results[0]}')

--- a/support/api_generation/custom_templates/client.mustache
+++ b/support/api_generation/custom_templates/client.mustache
@@ -1,32 +1,61 @@
 # custom-templates/my_client.mustache
 """DefectDojo Client"""
 
+from typing import Optional, Tuple, overload
+from urllib.request import proxy_bypass, getproxies
+from urllib.parse import urlparse
+
 from {{packageName}}.api_client import ApiClient as _ApiClient
 from {{packageName}}.configuration import Configuration
 
-from urllib.request import proxy_bypass, getproxies
-from urllib.parse import urlparse
 
 class DefectDojo:
     """API client for DefectDojo.
 
-    :param base_url: base URL of the DefectDojo instance.
+    :param base_url: Base URL of the DefectDojo instance.
     :param token: API token to use with DefectDojo.
         Use this OR auth, not both.
-    :param auth: tuple with username and password for basic authentication with DefectDojo.
+    :param auth: Tuple with username and password for basic authentication with DefectDojo.
         Use this OR token, not both.
+    :param verify_ssl: Set this to false to skip verifying SSL server certificate.
     :param config: Configuration object to use. If provided, all other parameters are ignored.
     """
 
-    def __init__(self, base_url: str, token: str = None, auth: tuple[str] = None, config: Configuration = None):
+    @overload
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        verify_ssl: bool = True,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        config: Configuration,
+    ): ...
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        auth: Optional[Tuple[str, str]] = None,
+        verify_ssl: bool = True,
+        config: Optional[Configuration] = None,
+    ):
         if token is not None and auth is not None:
             raise ValueError('Provide `token` OR `auth`, not both.')
         if auth is not None and (not isinstance(auth, tuple) or len(auth) != 2):
             raise ValueError('`auth` needs to be a tuple with 2 elements, username and password')
 
         if config is None:
-            # drop last / (if any) as it is already added as part of endpoints
-            kwargs = {'host': base_url.rstrip('/')}
+            kwargs = {}
+            if base_url is not None:
+                kwargs['host'] = base_url
 
             if token is not None:
                 kwargs.update({'api_key': {'tokenAuth': token}, 'api_key_prefix': {'tokenAuth': 'Token'}})
@@ -34,12 +63,12 @@ class DefectDojo:
                 kwargs.update({'username': auth[0], 'password': auth[1]})
 
             self.config = Configuration(**kwargs)
+            self.config.verify_ssl = verify_ssl
         else:
             self.config = config
 
-        # TODO: just python-requests as generator library...
-        if self.config.proxy is None:
-            scheme, host, *_ = urlparse(base_url)
+        if self.config.proxy is None and self.config.host:
+            scheme, host, *_ = urlparse(self.config.host)
             if not proxy_bypass(host):
                 self.config.proxy = getproxies().get(scheme)
 


### PR DESCRIPTION
`base_url` must be optional, as it is ignored if `config` is provided.

also, add verify_ssl as a quick shortcut (not part of Configuration constructor)

contributes to #18 and closes #3